### PR TITLE
Fix zip dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/apns.git", from: "4.2.0"),
         // used in tests
         .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.8.0"),
+        .package(url: "https://github.com/marmelroy/Zip.git", from: "2.1.0"),
     ],
     targets: [
         .target(
@@ -25,6 +26,7 @@ let package = Package(
                 .product(name: "Vapor", package: "vapor"),
                 .product(name: "Fluent", package: "fluent"),
                 .product(name: "VaporAPNS", package: "apns"),
+                .product(name: "Zip", package: "Zip"),
             ],
             swiftSettings: swiftSettings
         ),
@@ -34,6 +36,7 @@ let package = Package(
             dependencies: [
                 .target(name: "VaporWallet"),
                 .product(name: "FluentWalletPasses", package: "fluent-wallet"),
+                .product(name: "Zip", package: "Zip")
             ],
             swiftSettings: swiftSettings
         ),
@@ -43,6 +46,7 @@ let package = Package(
                 .target(name: "VaporWalletPasses"),
                 .product(name: "VaporTesting", package: "vapor"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                .product(name: "Zip", package: "Zip")
             ],
             resources: [
                 .copy("SourceFiles")
@@ -64,6 +68,7 @@ let package = Package(
                 .target(name: "VaporWalletOrders"),
                 .product(name: "VaporTesting", package: "vapor"),
                 .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                .product(name: "Zip", package: "Zip")
             ],
             resources: [
                 .copy("SourceFiles")

--- a/Sources/VaporWalletPasses/PassesServiceCustom.swift
+++ b/Sources/VaporWalletPasses/PassesServiceCustom.swift
@@ -174,11 +174,18 @@ extension PassesServiceCustom {
 
         var files: [ArchiveFile] = []
         for (i, pass) in passes.enumerated() {
-            try await files.append(ArchiveFile(filename: "pass\(i).pkpass", data: self.build(pass: pass, on: db)))
+            try await files
+                .append(
+                    ArchiveFile(
+                        filename: "pass\(i).pkpass",
+                        data: self.build(pass: pass, on: db) as NSData,
+                        modifiedTime: nil
+                    )
+                )
         }
 
         let zipFile = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).pkpass")
-        try Zip.zipData(archiveFiles: files, zipFilePath: zipFile)
+        try Zip.zipData(archiveFiles: files, zipFilePath: zipFile, password: nil, progress: nil)
         return try Data(contentsOf: zipFile)
     }
 }

--- a/Tests/VaporWalletOrdersTests/VaporWalletOrdersTests.swift
+++ b/Tests/VaporWalletOrdersTests/VaporWalletOrdersTests.swift
@@ -23,7 +23,7 @@ struct VaporWalletOrdersTests {
             let orderURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).order")
             try data.write(to: orderURL)
             let orderFolder = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-            try Zip.unzipFile(orderURL, destination: orderFolder)
+            try Zip.unzipFile(orderURL, destination: orderFolder, overwrite: true, password: nil, progress: nil)
 
             #expect(FileManager.default.fileExists(atPath: orderFolder.path.appending("/signature")))
 

--- a/Tests/VaporWalletPassesTests/VaporWalletPassesTests.swift
+++ b/Tests/VaporWalletPassesTests/VaporWalletPassesTests.swift
@@ -23,7 +23,7 @@ struct VaporWalletPassesTests {
             let passURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).pkpass")
             try data.write(to: passURL)
             let passFolder = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-            try Zip.unzipFile(passURL, destination: passFolder)
+            try Zip.unzipFile(passURL, destination: passFolder, overwrite: true, password: nil, progress: nil)
 
             #expect(FileManager.default.fileExists(atPath: passFolder.path.appending("/signature")))
 
@@ -84,7 +84,7 @@ struct VaporWalletPassesTests {
             let passURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UUID().uuidString).pkpass")
             try data.write(to: passURL)
             let passFolder = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
-            try Zip.unzipFile(passURL, destination: passFolder)
+            try Zip.unzipFile(passURL, destination: passFolder, overwrite: true, password: nil, progress: nil)
 
             #expect(FileManager.default.fileExists(atPath: passFolder.path.appending("/signature")))
 


### PR DESCRIPTION
Fixes vapor-community/wallet#21

Adding Zip dependency to fix build failures like:

`
Compiling VaporWalletOrders OrdersServiceCustom.swift /Users/runner/work/wallet/wallet/Sources/VaporWalletOrders/OrdersServiceCustom.swift:10:8: error: no such module 'Zip' 8 | import VaporWallet 9 | import WalletOrders 10 | import Zip |       - error: no such module 'Zip'`
`

For example see https://github.com/csknns/wallet/actions/runs/14143509636/job/39627981687?pr=2

linux test fail due to marmelroy/Zip#277
